### PR TITLE
.web-docs: remove community flag

### DIFF
--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -5,7 +5,6 @@ integration {
   name = "IPSW"
   description = "IPSW plugins for HashiCorp Packer"
   identifier = "packer/torarnv/ipsw"
-  flags = [ "community" ]
   docs {
     process_docs = true
   }


### PR DESCRIPTION
The community flag does not exist in the integrations API, so while the action succeeds, the documentation failed to be processed, hence why we end-up with an incomplete integration for the plugin at the moment.

Once this PR is merged, this will need to be re-ingested in order for the integrations API to process the plugin once more.